### PR TITLE
fetch data in nutrition log by date

### DIFF
--- a/topics-project/app/api/fetch-nutrition-via-date/[id]/[date]/route.js
+++ b/topics-project/app/api/fetch-nutrition-via-date/[id]/[date]/route.js
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+
+export async function GET(request, context) {
+  const { id, date } = context.params;
+
+  let new_date = new Date(date); // gets the date passed in and makes obj
+
+  let lowerbound_date = new_date.toISOString(); // turns the date into a str
+
+  let upperbound_date = new Date(date); // new date obj
+  upperbound_date.setDate(new_date.getDate() + 1); // make it exactly 1 day ahead
+  upperbound_date = upperbound_date.toISOString(); // turns it in string
+
+  const supabase = createClient();
+
+  const { data: nutrition_data, error } = await supabase
+    .from("nutrition_log")
+    .select("*")
+    .eq("uuid", id)
+    .gte("created_at", lowerbound_date) // get all foods gte date
+    .lte("created_at", upperbound_date); // but must be before the next day
+  // so range is from CURRENT day to the END of day
+
+  if (error) {
+    return NextResponse.json({ error: error });
+  }
+
+  return NextResponse.json({ data_by_date: nutrition_data });
+}


### PR DESCRIPTION
* created route at `http://localhost:3000/api/fetch-nutrition-via-date/<user_id>/<date>`

Route Details:
* you must pass in the following params into the URL
* **user_id** 
* **date** . for simplicity, try to pass in the date like so: mm-dd-yyyy
* the route will return each an empty array (if the user made entries on this day) , and an array of entries, or and error
* feel free to deconstruct this from the response and do whatever you like with the data

example:

```
lower:  2024-03-13T04:00:00.000Z
upper : 2024-03-14T04:00:00.000Z
```

anything between `Mar 23 2024` and before `March 24 2024` at **12 am** will be returned