### PR TITLE
added error handling to signup form

### DIFF
--- a/topics-project/app/(welcome)/(auth)/signup/actions.js
+++ b/topics-project/app/(welcome)/(auth)/signup/actions.js
@@ -1,6 +1,5 @@
 "use server";
 
-import { redirect } from "next/navigation";
 import { createClient } from "../../../../src/utils/supabase/server";
 
 export async function signup(formData) {
@@ -14,22 +13,15 @@ export async function signup(formData) {
         name: formData.name,
         height: formData.height,
         weight: formData.weight,
-        goal: formData.goal
-      }
-    }
-
+        goal: formData.goal,
+      },
+    },
   };
 
-  try {
-    const { error } = await supabase.auth.signUp(data);
-    if (error) {
-      throw error;
-    }
-    const { data: { user } } = await supabase.auth.getUser();
-    return user;
-
-  } catch (error) {
-    console.log(error);
-    redirect("/error");
+  const { error } = await supabase.auth.signUp(data);
+  if (error) {
+    throw error;
   }
+  const { data: { user } } = await supabase.auth.getUser();
+  return user;
 }

--- a/topics-project/app/(welcome)/(auth)/signup/page.js
+++ b/topics-project/app/(welcome)/(auth)/signup/page.js
@@ -4,11 +4,16 @@ import Link from 'next/link';
 import { useState } from "react";
 import { InfoForm } from "./_components/infoForm";
 import { MetricsForm } from "./_components/metricsForm";
-import { ChevronLeft } from "lucide-react"
+import { ChevronLeft, BadgeAlert } from "lucide-react";
+import {
+  Alert,
+  AlertTitle,
+} from "../../../../@/components/alert";
 
-import { signup } from "./actions"
+import { signup } from "./actions";
 
 export default function SignupPage() {
+  const [errorMsg, setErrorMsg] = useState("");
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -30,6 +35,12 @@ export default function SignupPage() {
   const [showNext, setShowNext] = useState(false);
   const toggleNext = (e) => {
     e.preventDefault();
+    if (formData.password !== formData.confirmPassword) {
+      setErrorMsg("Passwords do not match");
+      return;
+    } else {
+      setErrorMsg("");
+    }
     setShowNext(!showNext);
   };
 
@@ -40,13 +51,21 @@ export default function SignupPage() {
       if (user)
         window.location.href = "/";
     } catch (error) {
-      console.log(error);
-      window.location.href = "/error";
+      setErrorMsg(error.message);
     }
   }
 
   return (
     <div className="min-h-[calc(100vh-64px)] bg-[#FFF7ED] font-poppins">
+      {errorMsg != "" ? (
+        <div className="absolute top-0 left-0 right-0 mx-auto max-w-60 font-redHatText animate-fade-down animate-duration-300 animate-ease-in-out">
+          <Alert className="mt-6 rounded-md border-transparent bg-red-400 text-white flex items-center justify-center gap-2">
+            <BadgeAlert className="h-4 w-4" color="white" />
+            <AlertTitle>{errorMsg}</AlertTitle>
+          </Alert>
+        </div>
+      ) : null}
+
       <div className="min-h-[calc(100vh-64px)] flex flex-col justify-center items-center text-[#4C220A]">
         <div className="flex justify-between w-[300px] md:w-[400px] items-center mb-4">
 


### PR DESCRIPTION
As a user, I want to be able to see the reason why signup was not successful so I can fix the issue and try again. 


New PR because the old branch was having issues
- Fixed issue where signup form was not checking if password matched confirm password (Bug bash)
- Added error handling so all form errors show up on the page instead of simply redirecting user to /error
   - Errors include:
      - User already registered
      - Password must be atleast 6 characters long
      - Passwords do not match